### PR TITLE
Typo in "_base.scss" variable call

### DIFF
--- a/src/css/_base.scss
+++ b/src/css/_base.scss
@@ -51,7 +51,7 @@ body {
   font-family: 'Montserrat', sans-serif;
   font-weight: 400;
   line-height: 1.6;
-  color: var(--color-grey-light-1);
+  color: var(--color-grey-dark-1);
   background-color: var(--color-grey-light);
   background-size: cover;
   background-repeat: no-repeat;


### PR DESCRIPTION
I'm guessing the variable call "color: var(--color-grey-light-1);" for the body has a typo in it since it was not defined above and isn't actually changing the color of the text.
It's a small thing and the text looks good on the app regardless, but I noticed it and just wanted to help somehow :) 